### PR TITLE
Fix dinner string typo in risk router tests

### DIFF
--- a/tests/test_risk_router.py
+++ b/tests/test_risk_router.py
@@ -149,7 +149,7 @@ def test_live_risk_identification_valid_input():
         examples=['Fully booked restaurants.', 'Limited seating capacity.'],
     )
     request_data = RiskIdentificationRequest(
-        name='Going our for dinner.',
+        name='Going out for dinner.',
         context='Going out for dinner with friends at a local restaurant.',
         category=category.model_dump(),
     )
@@ -171,7 +171,7 @@ def test_live_risk_identification_valid_input_existing_risks():
         description='Friends or diners canceling their reservations unexpectedly, leading to less availability for the group.',
     )
     request_data = RiskIdentificationRequest(
-        name='Going our for dinner.',
+        name='Going out for dinner.',
         context='Going out for dinner with friends at a local restaurant.',
         category=category.model_dump(),
         existing=[risk1.model_dump()],
@@ -185,7 +185,7 @@ def test_live_risk_identification_valid_input_existing_risks():
 @pytest.mark.webtest
 def test_live_risk_drivers(project_request_data):
     request_data = RiskDriversRequest(
-        name='Going our for dinner.',
+        name='Going out for dinner.',
         context='Going out for dinner with friends at a local restaurant.',
         risk=Risk(
             title='Last-Minute Cancellations',


### PR DESCRIPTION
## Summary
- fix repeated typo in `tests/test_risk_router.py`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: FileNotFoundError regarding `.env`)*

------
https://chatgpt.com/codex/tasks/task_e_68429d759d64832d8907fde4a631c261