### PR TITLE
Add skeleton documentation with MkDocs

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,11 @@
+# Authentication
+
+The service uses JWT-based authentication. Clients obtain a token from the `/auth/login` endpoint of the data service. The token is stored as an HTTP-only cookie named `auth`.
+
+## Workflow
+1. The `login` route forwards credentials to the data service and sets the `auth` cookie.
+2. The `TokenExtractionMiddleware` reads the cookie on each request, decodes it using the secret defined in `.env`, and stores the token and `user_id` on `request.state`.
+3. Routes use the `get_current_user` dependency to ensure a valid token is present.
+4. `AuthService` checks the user's token quota via the data service before executing queries and reports consumed tokens afterwards.
+
+See `app/auth` for implementation details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,5 @@
+# AI Service Documentation
+
+Welcome to the documentation for the AI Service built with FastAPI. This site describes how to use the service and explains its internal architecture.
+
+- [Authentication](authentication.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,5 @@
+site_name: AI Service Docs
+nav:
+  - Home: index.md
+  - Authentication: authentication.md
+docs_dir: docs


### PR DESCRIPTION
## Summary
- set up simple MkDocs configuration
- add docs site with index and Authentication page

## Testing
- `pytest -q` *(fails: FileNotFoundError for .env)*

------
https://chatgpt.com/codex/tasks/task_e_6842ad371c20832d8ce325149f83c8da