### PR TITLE
Add RiskGPT service classes

### DIFF
--- a/app/risk/__init__.py
+++ b/app/risk/__init__.py
@@ -1,0 +1,32 @@
+from .service import (
+    RiskDefinitionService,
+    RiskIdentificationService,
+    RiskDriverService,
+    RiskLikelihoodService,
+    RiskImpactService,
+    RiskMitigationService,
+)
+
+from .riskgpt_service import (
+    RiskDefinitionCheckService as RiskGPTDefinitionCheckService,
+    RiskIdentificationService as RiskGPTRiskIdentificationService,
+    RiskDriverService as RiskGPTDriverService,
+    RiskLikelihoodService as RiskGPTLikelihoodService,
+    RiskImpactService as RiskGPTImpactService,
+    RiskMitigationService as RiskGPTMitigationService,
+)
+
+__all__ = [
+    'RiskDefinitionService',
+    'RiskIdentificationService',
+    'RiskDriverService',
+    'RiskLikelihoodService',
+    'RiskImpactService',
+    'RiskMitigationService',
+    'RiskGPTDefinitionCheckService',
+    'RiskGPTRiskIdentificationService',
+    'RiskGPTDriverService',
+    'RiskGPTLikelihoodService',
+    'RiskGPTImpactService',
+    'RiskGPTMitigationService',
+]

--- a/app/risk/riskgpt_service.py
+++ b/app/risk/riskgpt_service.py
@@ -1,0 +1,63 @@
+"""Services using the riskgpt library."""
+from __future__ import annotations
+
+from typing import Type
+
+from pydantic import BaseModel
+
+from riskgpt import chains
+from riskgpt.models import schemas as rg_schemas
+
+
+class RiskGPTService:
+    """Base service calling RiskGPT chains."""
+
+    chain_fn: callable
+    route_path: str
+    QueryModel: Type[BaseModel]
+    ResultModel: Type[BaseModel]
+
+    async def execute_query(self, query: BaseModel):
+        return await self.chain_fn(query)
+
+
+class RiskDefinitionCheckService(RiskGPTService):
+    chain_fn = chains.async_check_definition_chain
+    route_path = '/risk/check/definition/'
+    QueryModel = rg_schemas.DefinitionCheckRequest
+    ResultModel = rg_schemas.DefinitionCheckResponse
+
+
+class RiskIdentificationService(RiskGPTService):
+    chain_fn = chains.async_get_risks_chain
+    route_path = '/risk/identify/'
+    QueryModel = rg_schemas.RiskRequest
+    ResultModel = rg_schemas.RiskResponse
+
+
+class RiskDriverService(RiskGPTService):
+    chain_fn = chains.async_get_drivers_chain
+    route_path = '/risk/drivers/'
+    QueryModel = rg_schemas.DriverRequest
+    ResultModel = rg_schemas.DriverResponse
+
+
+class RiskLikelihoodService(RiskGPTService):
+    chain_fn = chains.async_get_assessment_chain
+    route_path = '/risk/likelihood/'
+    QueryModel = rg_schemas.AssessmentRequest
+    ResultModel = rg_schemas.AssessmentResponse
+
+
+class RiskImpactService(RiskGPTService):
+    chain_fn = chains.async_get_assessment_chain
+    route_path = '/risk/impact/'
+    QueryModel = rg_schemas.AssessmentRequest
+    ResultModel = rg_schemas.AssessmentResponse
+
+
+class RiskMitigationService(RiskGPTService):
+    chain_fn = chains.async_get_mitigations_chain
+    route_path = '/risk/mitigation/'
+    QueryModel = rg_schemas.MitigationRequest
+    ResultModel = rg_schemas.MitigationResponse


### PR DESCRIPTION
## Summary
- expose riskgpt-based services in `app.risk`
- implement new `RiskGPTService` base calling RiskGPT chains

## Testing
- `pip install -r requirements.txt --no-cache-dir`
- `pytest tests/test_risk_router.py::test_risk_definition_check_valid_input -q` *(fails: redis connection error)*

------
https://chatgpt.com/codex/tasks/task_e_68459e1fc0ac832d85b12d6fe68e5496