### PR TITLE
Implement response_info forwarding

### DIFF
--- a/app/auth/service.py
+++ b/app/auth/service.py
@@ -50,6 +50,16 @@ class TokenService:
             logger.error(f'Invalid tokens info: {e}')
             raise HTTPException(status_code=400, detail='Invalid tokens info')
 
+        response_info = getattr(result, 'response_info', None)
+
+        event_data = {
+            'tokens': payload.total_tokens,
+            'model': payload.model_name,
+            'prompt': payload.prompt_name,
+        }
+        if response_info is not None:
+            event_data['response_info'] = response_info
+
         event = CloudEvent(
             attributes={
                 'id': str(uuid.uuid4()),
@@ -57,11 +67,7 @@ class TokenService:
                 'source': settings.OPENMETER_SOURCE,
                 'subject': str(user_id),
             },
-            data={
-                'tokens': payload.total_tokens,
-                'model': payload.model_name,
-                'prompt': payload.prompt_name,
-            },
+            data=event_data,
         )
 
         self.client.ingest_events(to_dict(event))

--- a/app/core/registrar.py
+++ b/app/core/registrar.py
@@ -36,7 +36,11 @@ class BaseServiceHandler(Generic[TRequest, TResponse]):
         try:
             query = self.request_model(**request.model_dump())
             result = await service.execute_query(query)
-            return validate_model(result, self.response_model)
+            response_info = getattr(result, 'response_info', None)
+            validated = validate_model(result, self.response_model)
+            if response_info is not None:
+                setattr(validated, 'response_info', response_info)
+            return validated
 
         except AttributeError as ae:
             logging.error(f'Attribute error in {self.service_factory.__name__}: {ae}')

--- a/app/utils/schema.py
+++ b/app/utils/schema.py
@@ -4,4 +4,9 @@ from pydantic import BaseModel, Field
 
 
 class BaseResponseModel(BaseModel):
-    tokens_info: Optional[dict] = Field(..., description='The tokens consumed by the user.')
+    tokens_info: Optional[dict] = Field(
+        ..., description='The tokens consumed by the user.'
+    )
+    response_info: Optional[dict] = Field(
+        default=None, description='Additional response information.'
+    )


### PR DESCRIPTION
## Summary
- extend `BaseResponseModel` with optional `response_info`
- keep `response_info` in `BaseServiceHandler.handle`
- forward `response_info` to token consumption events

## Testing
- `PYTHONPATH=./app pytest -q` *(fails: pydantic validation errors and other issues)*

------
https://chatgpt.com/codex/tasks/task_e_68459e25a628832dba9c601f0f9047ef