### PR TITLE
Improve docs and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-Prompts can be defined under https://smith.langchain.com/prompts
+# AI Service
+
+## Setup
+
+1. Install Python 3.12 and create a virtual environment.
+2. Install dependencies using `pip install -r requirements.txt`.
+3. Copy `riskgpt.toml.example` to `riskgpt.toml` and adjust the configuration values according to your environment.
+4. Provide an `.env` file with the required API keys.
+
+## Development
+
+Run the tests excluding webtests:
+
+```bash
+pytest -m "not webtest"
+```
+
+Prompts can be defined under <https://smith.langchain.com/prompts>
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# AI Service
+
+This documentation is generated with [MkDocs](https://www.mkdocs.org/).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,3 @@
+site_name: AI Service Documentation
+nav:
+  - Home: index.md

--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -7,9 +7,8 @@ client = TestClient(app)
 
 
 def test_root():
-    response = client.get('/')
-    assert response.status_code == 200
-    assert response.json() == {'message': 'Hello World'}
+    response = client.get('/api/_health')
+    assert response.status_code == 204
 
 
 @pytest.mark.webtest

--- a/tests/test_risk_router.py
+++ b/tests/test_risk_router.py
@@ -3,29 +3,34 @@ from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
-from risk.schemas import (RiskDriversResponse, RiskImpactResponse,
-                          RiskLikelihoodResponse, RiskMitigationResponse)
+from app.risk.schemas import (
+    RiskDriversResponse,
+    RiskImpactResponse,
+    RiskLikelihoodResponse,
+    RiskMitigationResponse,
+)
 
 from app.category.schemas import Category
 from app.main import app
-from app.project.schemas import BaseProjectRequest
+from app.project.schemas import BaseProjectRequest, Project
 from app.risk.schemas import (Risk, RiskDefinitionCheckResponse,
                               RiskDriversRequest, RiskIdentificationRequest,
                               RiskIdentificationResponse)
 
-client = TestClient(app)
 
 
 @pytest.fixture(scope='function')
 def project_request_data():
     return BaseProjectRequest(
-        name='H2 Project',
-        context='Building a H2 cavern at an existing salt cavern site in the Netherlands. The budget is 100M EUR.',
+        project=Project(
+            name='H2 Project',
+            context='Building a H2 cavern at an existing salt cavern site in the Netherlands. The budget is 100M EUR.',
+        )
     ).model_dump()
 
 
 @patch('app.risk.service.RiskDefinitionService.execute_query')
-def test_risk_definition_check_valid_input(mock_execute_query):
+def test_risk_definition_check_valid_input(mock_execute_query, test_client):
     request_data = {'text': 'The project might face delays due to unforeseen circumstances.'}
     mock_execute_query.return_value = RiskDefinitionCheckResponse(
         is_valid=True,
@@ -33,8 +38,9 @@ def test_risk_definition_check_valid_input(mock_execute_query):
         original=request_data['text'],
         suggestion='Consider adding buffer time to the project schedule.',
         explanation='Delays can occur due to unforeseen circumstances, and having a buffer can mitigate this risk.',
+        tokens_info={},
     )
-    response = client.post('/api/risk/check/definition/', json=request_data)
+    response = test_client.post('/api/risk/check/definition/', json=request_data)
     assert response.status_code == 200
     mock_execute_query.assert_called_once()
     response_data = response.json()
@@ -47,46 +53,48 @@ def test_risk_definition_check_valid_input(mock_execute_query):
 
 
 @pytest.mark.webtest
-def test_Live_risk_definition_check_valid_input():
+def test_Live_risk_definition_check_valid_input(test_client):
     request_data = {'text': 'The project might face delays due to unforeseen circumstances.'}
-    response = client.post('/api/risk/check/definition/', json=request_data)
+    response = test_client.post('/api/risk/check/definition/', json=request_data)
     assert response.status_code == 200
     response_data = response.json()
     assert isinstance(RiskDefinitionCheckResponse(**response_data), RiskDefinitionCheckResponse)
 
 
 @patch('app.services.services.RiskDefinitionService.execute_query')
-def risk_definition_check_missing_text(mock_execute_query):
+def risk_definition_check_missing_text(mock_execute_query, test_client):
     request_data = {}
-    response = client.post('/api/risk-definition/check/', json=request_data)
+    response = test_client.post('/api/risk-definition/check/', json=request_data)
     assert response.status_code == 422
 
 
 @patch('app.services.services.RiskDefinitionService.execute_query')
-def risk_definition_check_empty_text(mock_execute_query):
+def risk_definition_check_empty_text(mock_execute_query, test_client):
     request_data = {'text': ''}
-    response = client.post('/api/risk-definition/check/', json=request_data)
+    response = test_client.post('/api/risk-definition/check/', json=request_data)
     assert response.status_code == 422
 
 
 @patch('app.services.services.RiskDefinitionService.execute_query')
-def risk_definition_check_invalid_text_type(mock_execute_query):
+def risk_definition_check_invalid_text_type(mock_execute_query, test_client):
     request_data = {'text': 12345}
-    response = client.post('/api/risk-definition/check/', json=request_data)
+    response = test_client.post('/api/risk-definition/check/', json=request_data)
     assert response.status_code == 422
 
 
 @pytest.fixture(scope='function')
 def risk_identification_request_data():
     return RiskIdentificationRequest(
-        name='Going out for dinner.',
-        context='Going out for dinner with friends at a local restaurant.',
+        project=Project(
+            name='Going out for dinner.',
+            context='Going out for dinner with friends at a local restaurant.',
+        ),
         category=Category(
             name='Operational',
             description='Challenges in securing a reservation at the desired restaurant.',
             examples=['Fully booked restaurants.', 'Limited seating capacity.'],
         ),
-        existing=[
+        risks=[
             {'title': 'Risk 1', 'description': 'Description of Risk 1'},
             {'title': 'Risk 2', 'description': 'Description of Risk 2'},
         ],
@@ -94,14 +102,15 @@ def risk_identification_request_data():
 
 
 @patch('app.risk.service.RiskIdentificationService.execute_query')
-def test_risk_identification_valid_input(mock_execute_query, risk_identification_request_data):
+def test_risk_identification_valid_input(mock_execute_query, test_client, risk_identification_request_data):
     mock_execute_query.return_value = RiskIdentificationResponse(
         risks=[
             Risk(title='Identified Risk 1', description='Description of Identified Risk 1'),
             Risk(title='Identified Risk 2', description='Description of Identified Risk 2'),
-        ]
+        ],
+        tokens_info={},
     )
-    response = client.post('/api/risk/identify/', json=risk_identification_request_data)
+    response = test_client.post('/api/risk/identify/', json=risk_identification_request_data)
     assert response.status_code == 200
     mock_execute_query.assert_called_once()
     response_data = response.json()
@@ -111,23 +120,24 @@ def test_risk_identification_valid_input(mock_execute_query, risk_identification
 
 
 @patch('app.risk.service.RiskIdentificationService.execute_query')
-def test_risk_identification_missing_category(mock_execute_query):
-    request_data = {'existing': [{'title': 'Risk 1', 'description': 'Description of Risk 1'}]}
-    response = client.post('/api/risk/identify/', json=request_data)
+def test_risk_identification_missing_category(mock_execute_query, test_client):
+    request_data = {'risks': [{'title': 'Risk 1', 'description': 'Description of Risk 1'}]}
+    response = test_client.post('/api/risk/identify/', json=request_data)
     assert response.status_code == 422
 
 
 @patch('app.risk.service.RiskIdentificationService.execute_query')
-def test_risk_identification_empty_existing(mock_execute_query, risk_identification_request_data):
+def test_risk_identification_empty_existing(mock_execute_query, test_client, risk_identification_request_data):
     mock_execute_query.return_value = RiskIdentificationResponse(
         risks=[
             Risk(title='Identified Risk 1', description='Description of Identified Risk 1'),
             Risk(title='Identified Risk 2', description='Description of Identified Risk 2'),
-        ]
+        ],
+        tokens_info={},
     )
     request_data = risk_identification_request_data
-    request_data['existing'] = []
-    response = client.post('/api/risk/identify/', json=request_data)
+    request_data['risks'] = []
+    response = test_client.post('/api/risk/identify/', json=request_data)
     assert response.status_code == 200
     mock_execute_query.assert_called_once()
     response_data = response.json()
@@ -135,9 +145,9 @@ def test_risk_identification_empty_existing(mock_execute_query, risk_identificat
 
 
 @patch('app.risk.service.RiskIdentificationService.execute_query')
-def test_risk_identification_invalid_existing_type(mock_execute_query):
-    request_data = {'category': 'Operational', 'existing': 'invalid_type'}
-    response = client.post('/api/risk/identify/', json=request_data)
+def test_risk_identification_invalid_existing_type(mock_execute_query, test_client):
+    request_data = {'category': 'Operational', 'risks': 'invalid_type'}
+    response = test_client.post('/api/risk/identify/', json=request_data)
     assert response.status_code == 422
 
 


### PR DESCRIPTION
## Summary
- update tests to use new models and adjust endpoints
- add mkdocs documentation scaffold
- update README with Python 3.12 and riskgpt config instructions

## Testing
- `pytest -m "not webtest" -q` *(fails: 6 failed, 12 passed, 13 deselected)*

------
https://chatgpt.com/codex/tasks/task_e_68459e4e6394832dbe56db1f9e929e01