### PR TITLE
Refactor conftest into plugins and fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,60 +1,6 @@
-import pytest
-from fastapi.testclient import TestClient
-
-from src.core.config import settings
-from src.main import app
-
-
-def pytest_addoption(parser):
-    parser.addoption(
-        '--webtest', action='store_true', default=False, help='run tests marked as webtest'
-    )
-
-
-def pytest_collection_modifyitems(config, items):
-    if config.getoption('--webtest'):
-        return
-    skip_webtest = pytest.mark.skip(reason='need --webtest option to run')
-    for item in items:
-        if 'webtest' in item.keywords:
-            item.add_marker(skip_webtest)
-
-
-@pytest.fixture(scope='session', autouse=True)
-def load_env():
-    settings.from_env()
-    assert settings.OPENAI_API_KEY, 'OPENAI_API_KEY is not set'
-    assert settings.LANGCHAIN_API_KEY, 'LANGCHAIN_API_KEY is not set'
-
-
-@pytest.fixture(autouse=True)
-def override_settings():
-    """Override settings for testing"""
-    original_redis_url = settings.REDIS_URL
-    settings.REDIS_URL = 'redis://localhost:6379'
-    yield
-    settings.REDIS_URL = original_redis_url
-
-
-@pytest.fixture(autouse=True)
-def override_auth(monkeypatch):
-    """Override authentication dependencies for tests."""
-
-    async def dummy_get_current_user(request):
-        return {'token': 'test', 'user_id': '00000000-0000-0000-0000-000000000000'}
-
-    from src.auth.dependencies import get_current_user
-    src.dependency_overrides[get_current_user] = dummy_get_current_user
-    monkeypatch.setattr('src.auth.service.TokenService.has_access', lambda self: True)
-    monkeypatch.setattr(
-        'src.auth.service.TokenService.consume_tokens',
-        lambda self, result, user_id: None,
-    )
-    yield
-    src.dependency_overrides.clear()
-
-
-@pytest.fixture
-def test_client(override_auth):
-    with TestClient(app) as client:
-        yield client
+pytest_plugins = [
+    'tests.plugins.webtest',
+    'tests.fixtures.env',
+    'tests.fixtures.auth',
+    'tests.fixtures.client',
+]

--- a/tests/fixtures/auth.py
+++ b/tests/fixtures/auth.py
@@ -1,0 +1,22 @@
+import pytest
+
+from src.main import app
+
+
+@pytest.fixture(autouse=True)
+def override_auth(monkeypatch):
+    """Override authentication dependencies for tests."""
+
+    async def dummy_get_current_user(request):
+        return {'token': 'test', 'user_id': '00000000-0000-0000-0000-000000000000'}
+
+    from src.auth.dependencies import get_current_user
+
+    app.dependency_overrides[get_current_user] = dummy_get_current_user
+    monkeypatch.setattr('src.auth.service.TokenService.has_access', lambda self: True)
+    monkeypatch.setattr(
+        'src.auth.service.TokenService.consume_tokens',
+        lambda self, result, user_id: None,
+    )
+    yield
+    app.dependency_overrides.clear()

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -1,0 +1,15 @@
+from fastapi.testclient import TestClient
+import pytest
+
+from src.main import app
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def test_client(client, override_auth):
+    yield client

--- a/tests/fixtures/env.py
+++ b/tests/fixtures/env.py
@@ -1,0 +1,20 @@
+import pytest
+
+from src.core.config import settings
+
+
+@pytest.fixture(scope='session', autouse=True)
+def load_env():
+    settings.from_env()
+    assert settings.OPENAI_API_KEY, 'OPENAI_API_KEY is not set'
+    assert settings.LANGCHAIN_API_KEY, 'LANGCHAIN_API_KEY is not set'
+
+
+@pytest.fixture(autouse=True)
+def override_settings(request):
+    """Override settings for testing."""
+    redis_url = getattr(request, 'param', 'redis://localhost:6379')
+    original_redis_url = settings.REDIS_URL
+    settings.REDIS_URL = redis_url
+    yield
+    settings.REDIS_URL = original_redis_url

--- a/tests/plugins/webtest.py
+++ b/tests/plugins/webtest.py
@@ -1,0 +1,16 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        '--webtest', action='store_true', default=False, help='run tests marked as webtest'
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption('--webtest'):
+        return
+    skip_webtest = pytest.mark.skip(reason='need --webtest option to run')
+    for item in items:
+        if 'webtest' in item.keywords:
+            item.add_marker(skip_webtest)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,20 @@
+import types
+import pytest
+
+from tests.fixtures.env import override_settings
+from src.core.config import settings
+
+
+class DummyRequest:
+    def __init__(self, param=None):
+        self.param = param
+
+
+def test_override_settings_resets_after_use():
+    original = settings.REDIS_URL
+    gen = override_settings(DummyRequest('redis://example:6380'))
+    next(gen)
+    assert settings.REDIS_URL == 'redis://example:6380'
+    with pytest.raises(StopIteration):
+        next(gen)
+    assert settings.REDIS_URL == original


### PR DESCRIPTION
## Summary
- split `tests/conftest.py` into plugin and fixture modules
- create plugins for webtest options
- create fixtures for environment settings, auth overrides and test clients
- add regression test for `override_settings`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6845ab2acd94832dab67975299d1b8ba