### PR TITLE
Integrate RiskGPT via dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ pytest -m "not webtest"
 
 Prompts can be defined under <https://smith.langchain.com/prompts>
 
+### Category endpoint
+
+Risk categories are generated via the [RiskGPT](https://pypi.org/project/riskgpt/)
+library (Python 3.12+). Install it separately and provide a valid
+`riskgpt.toml` configuration. Send a `CategoryRequest` to
+`/api/categories/` to receive a list of categories and an optional rationale.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,10 @@
 # AI Service
 
 This documentation is generated with [MkDocs](https://www.mkdocs.org/).
+
+## Category detection
+
+The `/api/categories/` endpoint uses the
+[RiskGPT](https://pypi.org/project/riskgpt/) library (requires Python 3.12)
+to return relevant categories for a project description. Ensure that the
+package and its configuration file are installed.

--- a/src/category/__init__.py
+++ b/src/category/__init__.py
@@ -1,0 +1,16 @@
+from .service import (
+    AddRiskCategoriesService,
+    AddOpportunitiesCategoriesService,
+    CreateRiskCategoriesService,
+    CreateOpportunitiesCategoriesService,
+)
+
+from .riskgpt_service import RiskGPTCategoryService
+
+__all__ = [
+    'AddRiskCategoriesService',
+    'AddOpportunitiesCategoriesService',
+    'CreateRiskCategoriesService',
+    'CreateOpportunitiesCategoriesService',
+    'RiskGPTCategoryService',
+]

--- a/src/category/riskgpt_service.py
+++ b/src/category/riskgpt_service.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Type
+
+from pydantic import BaseModel
+
+try:  # pragma: no cover - optional dependency
+    from riskgpt import chains
+    from riskgpt.models.schemas import CategoryRequest, CategoryResponse
+except Exception:  # pragma: no cover - riskgpt not installed
+    chains = None
+
+    class CategoryRequest(BaseModel):
+        """Fallback request schema when riskgpt is unavailable."""
+
+        project_id: str
+        project_description: str
+        domain_knowledge: str | None = None
+        language: str | None = "en"
+
+    class CategoryResponse(BaseModel):
+        """Fallback response schema when riskgpt is unavailable."""
+
+        categories: list[str]
+        rationale: str | None = None
+        response_info: dict | None = None
+
+
+class RiskGPTCategoryService:
+    """Service wrapping RiskGPT category chain."""
+
+    chain_fn = chains.async_get_categories_chain if chains else None
+    route_path = '/categories/'
+    QueryModel: Type[BaseModel] = CategoryRequest
+    ResultModel: Type[BaseModel] = CategoryResponse
+
+    async def execute_query(self, query: BaseModel):
+        if not self.chain_fn:
+            raise RuntimeError('riskgpt is not installed')
+        return await self.chain_fn(query)

--- a/tests/test_category_router.py
+++ b/tests/test_category_router.py
@@ -1,64 +1,31 @@
 from unittest.mock import patch
 
 import pytest
-from fastapi.testclient import TestClient
+from fastapi.testclient import TestClient  # noqa: F401
 
-from src.category.schemas import (
-    BaseProjectRequest,
-    AddCategoriesRequest,
-    IdentifiedCategory,
-    CategoriesResponse,
+from src.category.riskgpt_service import (
+    CategoryRequest,
+    CategoryResponse,
+    RiskGPTCategoryService,
 )
-from src.project.schemas import Project
 from src.main import app
 
 
-@pytest.fixture(scope='function')
-def project_request_data():
-    return BaseProjectRequest(
-        project=Project(
-            name='H2 Project',
-            context='Building a H2 cavern at an existing salt cavern site in the Netherlands. The budget is 100M EUR.',
-        )
-    ).model_dump()
-
-
-@patch('src.category.service.AddRiskCategoriesService.execute_query')
+@patch('src.category.riskgpt_service.RiskGPTCategoryService.execute_query')
 def test_category_identification(mock_execute_query, test_client):
-    data = AddCategoriesRequest(
-        project=Project(
-            name='Removal of a wasp nest.',
-            context='Removal of a wasp nest by a service company within the next week.',
-        ),
-        categories=[],
-        type='risk',
+    data = CategoryRequest(
+        project_id='1',
+        project_description='Removal of a wasp nest by a service company within the next week.',
     )
-    mock_execute_query.return_value = CategoriesResponse(
-        categories=[
-            IdentifiedCategory(
-                name='Sample',
-                description='A sample category.',
-                examples=['Example 1', 'Example 2'],
-                confidence=0.95,
-                subcategories=[],
-            ),
-            IdentifiedCategory(
-                name='Text',
-                description='A text category.',
-                examples=['Example 3', 'Example 4'],
-                confidence=0.85,
-                subcategories=[],
-            ),
-        ],
-        tokens_info={},
+    mock_execute_query.return_value = CategoryResponse(
+        categories=['Sample', 'Text'],
+        rationale='demo',
+        response_info=None,
     )
-    response = test_client.post('/api/categories/risk/add/', json=data.model_dump())
+    response = test_client.post('/api/categories/', json=data.model_dump())
     assert response.status_code == 200
     mock_execute_query.assert_called_once()
     response_data = response.json()
-    assert isinstance(
-        CategoriesResponse(**response_data),
-        CategoriesResponse,
-    )
+    assert CategoryResponse(**response_data)
     assert len(response_data['categories']) == 2
-    assert response_data['categories'][0]['name'] == 'Sample'
+    assert response_data['categories'][0] == 'Sample'


### PR DESCRIPTION
## Summary
- delete bundled RiskGPT code
- implement fallback stubs when RiskGPT isn't installed
- adjust tests to use stubs
- document RiskGPT as optional dependency

## Testing
- `ruff check .` *(fails: unused imports and undefined names)*
- `pytest tests/test_category_router.py::test_category_identification -q` *(fails: ModuleNotFoundError for dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_6845ac557838832d8cc19f1b43159711