### PR TITLE
Refactor logging setup

### DIFF
--- a/app/core/logger.py
+++ b/app/core/logger.py
@@ -2,31 +2,19 @@ import logging
 import sys
 
 from .config import settings
-
-LOG_LEVEL = getattr(logging, settings.LOG_LEVEL.upper(), logging.INFO)
-
-
-class CustomFormatter(logging.Formatter):
-    def format(self, record):
-        levelname = record.levelname
-        if levelname == 'INFO':
-            levelname = 'INFO:    '
-        elif levelname == 'DEBUG':
-            levelname = 'DEBUG:   '
-        elif levelname == 'WARNING':
-            levelname = 'WARNING: '
-        elif levelname == 'ERROR':
-            levelname = 'ERROR:   '
-        elif levelname == 'CRITICAL':
-            levelname = 'CRITICAL:'
-        record.levelname = levelname
-        return super().format(record)
+from .logging_formatter import CustomFormatter
 
 
-formatter = CustomFormatter('%(levelname)s [%(name)s] %(message)s')
+def configure_logging(level: str | None = None, stream=sys.stdout) -> None:
+    """Configure application logging."""
+    level_name = level or settings.LOG_LEVEL
+    log_level = getattr(logging, level_name.upper(), logging.INFO)
 
-logging.basicConfig(level=LOG_LEVEL, handlers=[logging.StreamHandler(sys.stdout)])
-
-
-for handler in logging.root.handlers:
+    handler = logging.StreamHandler(stream)
+    formatter = CustomFormatter('%(levelname)s [%(name)s] %(message)s')
     handler.setFormatter(formatter)
+
+    logging.basicConfig(level=log_level, handlers=[handler])
+
+    for h in logging.root.handlers:
+        h.setFormatter(formatter)

--- a/app/core/logging_formatter.py
+++ b/app/core/logging_formatter.py
@@ -1,0 +1,18 @@
+import logging
+
+
+class CustomFormatter(logging.Formatter):
+    def format(self, record):
+        levelname = record.levelname
+        if levelname == 'INFO':
+            levelname = 'INFO:    '
+        elif levelname == 'DEBUG':
+            levelname = 'DEBUG:   '
+        elif levelname == 'WARNING':
+            levelname = 'WARNING: '
+        elif levelname == 'ERROR':
+            levelname = 'ERROR:   '
+        elif levelname == 'CRITICAL':
+            levelname = 'CRITICAL:'
+        record.levelname = levelname
+        return super().format(record)

--- a/app/main.py
+++ b/app/main.py
@@ -8,11 +8,14 @@ from starlette.middleware.cors import CORSMiddleware
 from app.auth.router import router as auth_router
 from app.core.config import settings
 from app.core.health_checks import router as core_router
-from app.core.logger import logging
+import logging
+from app.core.logger import configure_logging
 from app.keywords.router import router as keywords_router
 from app.middleware.custom_error_format import custom_error_format_middleware
 from app.middleware.token_extraction import TokenExtractionMiddleware
 from app.router import router as base_router
+
+configure_logging()
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- move `CustomFormatter` to `logging_formatter.py`
- simplify logging configuration with `configure_logging()`
- use `configure_logging()` during app startup

## Testing
- `ruff check app/core/logging_formatter.py app/core/logger.py app/main.py`
- `ruff format app/core/logging_formatter.py app/core/logger.py app/main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_6845b1b2a958832d9b5b949e517cc919