### PR TITLE
Add environment example and setup instructions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+OPENAI_API_KEY=your-key
+LANGCHAIN_API_KEY=your-key
+LANGCHAIN_PROJECT=your-project
+DATASERVICE_URL=http://localhost
+SENTRY_DSN=http://public:secret@localhost/1
+SECRET_KEY=change-me
+REDIS_URL=redis://localhost:6379/0

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 Prompts can be defined under https://smith.langchain.com/prompts
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in the appropriate values.
+2. Start a local Redis server using `redis-server`.
+3. Install dependencies and run the tests:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+


### PR DESCRIPTION
## Summary
- provide `.env.example` with placeholder values
- explain setup steps in README

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: FileNotFoundError for /.env)*

------
https://chatgpt.com/codex/tasks/task_e_6845c2f4e1b4832d9c9ab5ce16e39546