### PR TITLE
Use pytest-dotenv for test environment

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,7 @@
+OPENAI_API_KEY=test-openai-key
+LANGCHAIN_API_KEY=test-langchain-key
+LANGCHAIN_PROJECT=test-project
+SENTRY_DSN=http://example.com/0
+SECRET_KEY=test-secret
+OPENMETER_API_KEY=test-openmeter-key
+

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 
 ## Development
 
-Run the tests excluding webtests:
+Run the tests excluding webtests. Environment variables are loaded from
+`.env.test` using `pytest-dotenv`:
 
 ```bash
 pytest -m "not webtest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ riskgpt = ">=0.1.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"
+pytest-dotenv = "^0.5.2"
 isort = "^5.13.2"
 ruff = "^0.6.9"
 
@@ -49,3 +50,4 @@ markers = [
     "webtest: marks tests that access external APIs (select with '-m webtest')",
     "tryfirst: marks tests that should be run first",
 ]
+dotenv_file = ".env.test"

--- a/tests/fixtures/env.py
+++ b/tests/fixtures/env.py
@@ -1,20 +1,21 @@
+import importlib
 import pytest
-
-from src.core.config import settings
 
 
 @pytest.fixture(scope='session', autouse=True)
 def load_env():
-    settings.from_env()
-    assert settings.OPENAI_API_KEY, 'OPENAI_API_KEY is not set'
-    assert settings.LANGCHAIN_API_KEY, 'LANGCHAIN_API_KEY is not set'
+    from src.core import config
+    importlib.reload(config)
+    assert config.settings.OPENAI_API_KEY, 'OPENAI_API_KEY is not set'
+    assert config.settings.LANGCHAIN_API_KEY, 'LANGCHAIN_API_KEY is not set'
 
 
 @pytest.fixture(autouse=True)
 def override_settings(request):
     """Override settings for testing."""
+    from src.core import config
     redis_url = getattr(request, 'param', 'redis://localhost:6379')
-    original_redis_url = settings.REDIS_URL
-    settings.REDIS_URL = redis_url
+    original_redis_url = config.settings.REDIS_URL
+    config.settings.REDIS_URL = redis_url
     yield
-    settings.REDIS_URL = original_redis_url
+    config.settings.REDIS_URL = original_redis_url


### PR DESCRIPTION
## Summary
- add `pytest-dotenv` for tests
- load env variables from `.env.test`
- reload settings in fixtures after env is loaded
- document the new behaviour

## Testing
- `pytest -m "not webtest"` *(fails: No module named 'langchain')*

------
https://chatgpt.com/codex/tasks/task_e_6845c4f9e154832d809d5e70096b9b2f