### PR TITLE
Refactor AIService to use RiskGPT wrapper

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+env_files = .env.test


### PR DESCRIPTION
## Summary
- convert AIService to build chains via RiskGPT
- load test environment variables via pytest.ini

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openmeter')*

------
https://chatgpt.com/codex/tasks/task_e_6845ce041718832d9639de24b5ed8244