### PR TITLE
Fix fallback error in resilient execution

### DIFF
--- a/src/utils/resilient.py
+++ b/src/utils/resilient.py
@@ -3,11 +3,11 @@
 This module provides utilities for making service calls more resilient,
 combining circuit breaker pattern with fallback functionality.
 """
+
 import logging
 from functools import wraps
-from typing import Callable, TypeVar, Any, Optional
+from typing import Callable, TypeVar, Optional
 
-from riskgpt.utils import with_fallback
 from src.utils.circuit_breaker import get_circuit_breaker
 from src.utils.exceptions import ExternalServiceException
 
@@ -16,6 +16,7 @@ T = TypeVar('T')
 
 # Configure logger
 logger = logging.getLogger(__name__)
+
 
 def with_resilient_execution(service_name, create_default_response: Optional[Callable] = None):
     """Decorator that combines circuit breaker and fallback functionality.
@@ -29,6 +30,7 @@ def with_resilient_execution(service_name, create_default_response: Optional[Cal
     Returns:
         Decorated function with circuit breaker and fallback protection
     """
+
     def decorator(func: Callable[..., T]) -> Callable[..., T]:
         @wraps(func)
         async def wrapper(*args, **kwargs) -> T:
@@ -39,47 +41,27 @@ def with_resilient_execution(service_name, create_default_response: Optional[Cal
 
             # If circuit is open, fail fast
             if not circuit.allow_request():
-                logger.warning(f"Circuit breaker for {svc_name} is open, failing fast")
+                logger.warning(f'Circuit breaker for {svc_name} is open, failing fast')
                 if create_default_response:
                     return create_default_response(*args, **kwargs)
                 raise ExternalServiceException(
-                    detail=f"Service {svc_name} is currently unavailable",
-                    service_name=svc_name
-                )
-
-            async def fallback_function(error: Any, *fb_args, **fb_kwargs):
-                # Record failure in circuit breaker
-                circuit.record_failure()
-
-                # Log the error
-                logger.warning(f"Service {svc_name} failed: {error}")
-
-                # Return a default response if provided, otherwise raise exception
-                if create_default_response:
-                    return create_default_response(*fb_args, **fb_kwargs)
-                raise ExternalServiceException(
-                    detail=f"Service {svc_name} failed: {str(error)}",
-                    service_name=svc_name
+                    detail=f'Service {svc_name} is currently unavailable', service_name=svc_name
                 )
 
             try:
-                # Use with_fallback to wrap the function
-                result = await with_fallback(
-                    function=lambda: func(*args, **kwargs),
-                    fallback_function=fallback_function,
-                    fallback_args=args,
-                    fallback_kwargs=kwargs
-                )
-
-                # Record success in circuit breaker
+                result = await func(*args, **kwargs)
                 circuit.record_success()
                 return result
-
-            except Exception as e:
-                # Record failure in circuit breaker
+            except Exception as error:  # pragma: no cover - unexpected error
                 circuit.record_failure()
-                # Re-raise the exception
-                raise
+                logger.warning(f'Service {svc_name} failed: {error}')
+                if create_default_response:
+                    return create_default_response(*args, **kwargs)
+                raise ExternalServiceException(
+                    detail=f'Service {svc_name} failed: {str(error)}',
+                    service_name=svc_name,
+                )
 
         return wrapper
+
     return decorator

--- a/tests/utils/test_resilient.py
+++ b/tests/utils/test_resilient.py
@@ -1,93 +1,118 @@
 """Tests for the resilient execution utilities."""
+
 import pytest
-from unittest.mock import patch, MagicMock, AsyncMock
+from unittest.mock import MagicMock, AsyncMock
 
 from src.utils.resilient import with_resilient_execution
 from src.utils.exceptions import ExternalServiceException
 
+
 @pytest.mark.asyncio
 async def test_with_resilient_execution_success():
     """Test that the decorator allows successful calls."""
-    mock_func = AsyncMock(return_value="success")
-    
-    @with_resilient_execution(service_name="test")
+    mock_func = AsyncMock(return_value='success')
+
+    @with_resilient_execution(service_name='test')
     async def test_func():
         return await mock_func()
-    
+
     result = await test_func()
-    
-    assert result == "success"
+
+    assert result == 'success'
     mock_func.assert_called_once()
+
 
 @pytest.mark.asyncio
 async def test_with_resilient_execution_failure_with_fallback():
     """Test that the decorator handles failures with fallback."""
-    mock_func = AsyncMock(side_effect=Exception("test error"))
-    mock_fallback = MagicMock(return_value="fallback")
-    
-    @with_resilient_execution(service_name="test_fallback", create_default_response=mock_fallback)
+    mock_func = AsyncMock(side_effect=Exception('test error'))
+    mock_fallback = MagicMock(return_value='fallback')
+
+    @with_resilient_execution(service_name='test_fallback', create_default_response=mock_fallback)
     async def test_func():
         return await mock_func()
-    
+
     result = await test_func()
-    
-    assert result == "fallback"
+
+    assert result == 'fallback'
     mock_func.assert_called_once()
     mock_fallback.assert_called_once()
+
 
 @pytest.mark.asyncio
 async def test_with_resilient_execution_dynamic_service_name():
     """Test that the decorator handles dynamic service names."""
-    mock_func = AsyncMock(return_value="success")
-    
-    @with_resilient_execution(service_name=lambda x: f"service_{x}")
+    mock_func = AsyncMock(return_value='success')
+
+    @with_resilient_execution(service_name=lambda x: f'service_{x}')
     async def test_func(x):
         return await mock_func()
-    
+
     result = await test_func(123)
-    
-    assert result == "success"
+
+    assert result == 'success'
     mock_func.assert_called_once()
+
 
 @pytest.mark.asyncio
 async def test_with_resilient_execution_circuit_open():
     """Test that the decorator fails fast when the circuit is open."""
     # Create a circuit breaker and open it
     from src.utils.circuit_breaker import _circuit_breakers, CircuitBreaker
-    cb = CircuitBreaker(name="test_open", failure_threshold=1)
-    _circuit_breakers["test_open"] = cb
+
+    cb = CircuitBreaker(name='test_open', failure_threshold=1)
+    _circuit_breakers['test_open'] = cb
     cb.record_failure()  # Open the circuit
-    
-    mock_func = AsyncMock(return_value="success")
-    
-    @with_resilient_execution(service_name="test_open")
+
+    mock_func = AsyncMock(return_value='success')
+
+    @with_resilient_execution(service_name='test_open')
     async def test_func():
         return await mock_func()
-    
+
     # Should raise ExternalServiceException without calling the function
-    with pytest.raises(ExternalServiceException, match="Service test_open is currently unavailable"):
+    with pytest.raises(
+        ExternalServiceException, match='Service test_open is currently unavailable'
+    ):
         await test_func()
-    
+
     mock_func.assert_not_called()
+
 
 @pytest.mark.asyncio
 async def test_with_resilient_execution_circuit_open_with_fallback():
     """Test that the decorator returns the fallback when the circuit is open."""
     # Create a circuit breaker and open it
     from src.utils.circuit_breaker import _circuit_breakers, CircuitBreaker
-    cb = CircuitBreaker(name="test_open_fallback", failure_threshold=1)
-    _circuit_breakers["test_open_fallback"] = cb
+
+    cb = CircuitBreaker(name='test_open_fallback', failure_threshold=1)
+    _circuit_breakers['test_open_fallback'] = cb
     cb.record_failure()  # Open the circuit
-    
-    mock_func = AsyncMock(return_value="success")
-    mock_fallback = MagicMock(return_value="fallback")
-    
-    @with_resilient_execution(service_name="test_open_fallback", create_default_response=mock_fallback)
+
+    mock_func = AsyncMock(return_value='success')
+    mock_fallback = MagicMock(return_value='fallback')
+
+    @with_resilient_execution(
+        service_name='test_open_fallback', create_default_response=mock_fallback
+    )
     async def test_func():
         return await mock_func()
-    
+
     result = await test_func()
-    
-    assert result == "fallback"
+
+    assert result == 'fallback'
     mock_func.assert_not_called()
     mock_fallback.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_with_resilient_execution_error_no_fallback():
+    """Ensure unexpected errors raise ExternalServiceException."""
+
+    async def failing():
+        raise RuntimeError('boom')
+
+    wrapped = with_resilient_execution(service_name='svc')(failing)
+
+    with pytest.raises(ExternalServiceException, match='boom'):
+        await wrapped()


### PR DESCRIPTION
## Summary
- remove dependency on RiskGPT with_fallback
- handle fallback logic internally in resilient execution decorator
- cover unexpected error case in test suite

## Testing
- `ruff format src/utils/resilient.py tests/utils/test_resilient.py`
- `ruff check src/utils/resilient.py tests/utils/test_resilient.py`
- `pytest tests/utils/test_resilient.py::test_with_resilient_execution_error_no_fallback -q` *(fails: could not import riskgpt)*

------
https://chatgpt.com/codex/tasks/task_e_68480f8167c4832dbf2d376b86bda566