### PR TITLE
Fix chain_fn invocation

### DIFF
--- a/src/services/base_service.py
+++ b/src/services/base_service.py
@@ -117,4 +117,4 @@ class BaseService:
         Returns:
             The result of the chain function.
         """
-        return await self.chain_fn(query)
+        return await self.__class__.chain_fn(query)

--- a/tests/services/test_base_service.py
+++ b/tests/services/test_base_service.py
@@ -31,7 +31,7 @@ async def test_base_service_execute_query_success():
     
     # Create a test service with the mock chain function
     service = TestService()
-    service.chain_fn = mock_chain_fn
+    service.__class__.chain_fn = mock_chain_fn
     
     # Execute a query
     query = TestQueryModel(query="test query")
@@ -50,7 +50,7 @@ async def test_base_service_execute_query_failure():
     
     # Create a test service with the mock chain function
     service = TestService()
-    service.chain_fn = mock_chain_fn
+    service.__class__.chain_fn = mock_chain_fn
     
     # Execute a query - should return a fallback response
     query = TestQueryModel(query="test query")
@@ -69,7 +69,7 @@ async def test_base_service_execute_query_circuit_open():
     
     # Create a test service with the mock chain function
     service = TestService()
-    service.chain_fn = mock_chain_fn
+    service.__class__.chain_fn = mock_chain_fn
     
     # Open the circuit for the service
     from src.utils.circuit_breaker import _circuit_breakers, CircuitBreaker
@@ -91,7 +91,7 @@ async def test_base_service_execute_query_no_chain_fn():
     """Test that execute_query raises RuntimeError when chain_fn is not set."""
     # Create a test service without a chain function
     service = TestService()
-    service.chain_fn = None
+    service.__class__.chain_fn = None
     
     # Execute a query - should raise RuntimeError
     query = TestQueryModel(query="test query")


### PR DESCRIPTION
## Summary
- call chain functions via class attribute to avoid binding
- adapt tests to patch chain_fn on the class

## Testing
- `pre-commit run --files src/services/base_service.py tests/services/test_base_service.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68485b953068832d9d6163d950e4e628