### PR TITLE
Add empty body assertion to test_root

### DIFF
--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -9,6 +9,7 @@ client = TestClient(app)
 def test_root():
     response = client.get("/api/_health")
     assert response.status_code == 204
+    assert response.content == b""
 
 
 @pytest.mark.webtest


### PR DESCRIPTION
## Summary
- ensure `/api/_health` endpoint returns no content

## Testing
- `pytest tests/test_basis.py::test_root -q`

------
https://chatgpt.com/codex/tasks/task_e_684945112acc832dacea8fcd318e4a4d