### PR TITLE
Fix CORS preflight test path and method assertions

### DIFF
--- a/tests/test_basis.py
+++ b/tests/test_basis.py
@@ -14,12 +14,13 @@ def test_root():
 @pytest.mark.webtest
 @pytest.mark.tryfirst
 def test_cors_headers_are_present():
-    response = client.options("api/keywords/extract/", headers={"Origin": "http://localhost:3000"})
+    response = client.options("/api/keywords/extract/", headers={"Origin": "http://localhost:3000"})
     assert response.status_code == 200
     assert "access-control-allow-origin" in response.headers
     assert response.headers["access-control-allow-origin"] == "http://localhost:3000"
     assert "access-control-allow-methods" in response.headers
     assert "OPTIONS" in response.headers["access-control-allow-methods"]
+    assert "POST" in response.headers["access-control-allow-methods"]
 
 
 @pytest.mark.webtest


### PR DESCRIPTION
## Summary
- update CORS preflight test to call `/api/keywords/extract/`
- assert that allowed methods include both OPTIONS and POST

## Testing
- `pytest -k test_basis.py::test_cors_headers_are_present -vv` *(fails: ValidationError for Settings)*

------
https://chatgpt.com/codex/tasks/task_e_684945286af0832dacaf85fdd8418029