### PR TITLE
Fix service chain monkeypatch

### DIFF
--- a/tests/services/test_services_chains.py
+++ b/tests/services/test_services_chains.py
@@ -67,7 +67,7 @@ async def test_service_executes_chain(monkeypatch, service_cls, chain_path):
         pytest.skip(f"Could not create example model for {service_cls.__name__}: {e}")
 
     svc = service_cls()
-    monkeypatch.setattr(svc, "chain_fn", mock_chain)
+    monkeypatch.setattr(service_cls, "chain_fn", mock_chain)
     query = service_cls.QueryModel.model_validate(EXAMPLES[service_cls.QueryModel])
 
     # Test that execute_query returns the result of the chain
@@ -92,7 +92,7 @@ async def test_service_fallback(monkeypatch, service_cls, chain_path):
     # Create a mock that raises an exception
     mock_chain = AsyncMock(side_effect=Exception("boom"))
     svc = service_cls()
-    monkeypatch.setattr(svc, "chain_fn", mock_chain)
+    monkeypatch.setattr(service_cls, "chain_fn", mock_chain)
     query = service_cls.QueryModel.model_validate(EXAMPLES[service_cls.QueryModel])
 
     # Test that execute_query handles the failure appropriately


### PR DESCRIPTION
## Summary
- fix monkeypatching of `chain_fn` to patch the service class directly

## Testing
- `pre-commit run --files tests/services/test_services_chains.py`
- `poetry run pytest tests/services/test_services_chains.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6849453e8f2c832da906b1143bb84d28