### PR TITLE
Refactor fallback tests

### DIFF
--- a/tests/services/test_services_chains.py
+++ b/tests/services/test_services_chains.py
@@ -77,36 +77,32 @@ async def test_service_executes_chain(monkeypatch, service_cls, chain_path):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("use_fallback", [True, False])
 @pytest.mark.parametrize("service_cls,chain_path", SERVICE_PARAMS)
 @pytest.mark.skip(reason="Skipping due to validation errors in response models")
-async def test_service_fallback(monkeypatch, service_cls, chain_path):
+async def test_service_fallback(monkeypatch, service_cls, chain_path, use_fallback):
     """Test that services handle failures appropriately.
 
-    This test verifies that when a service chain fails, the service either:
-    1. Returns a fallback response, or
-    2. Raises an ExternalServiceException
-
-    Both behaviors are acceptable, as they prevent the original exception from
-    propagating to the caller.
+    If ``use_fallback`` is ``True`` the service should return a valid ``ResultModel``
+    instance. Otherwise an ``ExternalServiceException`` is expected.
     """
-    # Create a mock that raises an exception
+
+    from src.utils.exceptions import ExternalServiceException
+
     mock_chain = AsyncMock(side_effect=Exception("boom"))
     svc = service_cls()
     monkeypatch.setattr(svc, "chain_fn", mock_chain)
+
+    if not use_fallback:
+        monkeypatch.setattr(svc, "_create_default_response", AsyncMock(side_effect=Exception("fail")))
+
     query = service_cls.QueryModel.model_validate(EXAMPLES[service_cls.QueryModel])
 
-    # Test that execute_query handles the failure appropriately
-    try:
-        # Try to execute the query
-        await svc.execute_query(query)
-        # If we get here, the service returned a fallback response
+    if use_fallback:
+        result = await svc.execute_query(query)
         mock_chain.assert_awaited_once_with(query)
-    except Exception as e:
-        # If we get here, the service raised an exception
-        # This is acceptable if it's an ExternalServiceException
-        from src.utils.exceptions import ExternalServiceException
-
-        if not isinstance(e, ExternalServiceException):
-            pytest.fail(f"Service {service_cls.__name__} raised an unexpected exception: {e}")
-        # The test passes if the exception is an ExternalServiceException
+        assert isinstance(result, service_cls.ResultModel)
+    else:
+        with pytest.raises(ExternalServiceException):
+            await svc.execute_query(query)
         mock_chain.assert_awaited_once_with(query)


### PR DESCRIPTION
## Summary
- refactor fallback test to use pytest.raises
- parametrize fallback and error scenarios

## Testing
- `pytest tests/services/test_services_chains.py::test_service_fallback -vv -s` *(fails: collected tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_6849454d5580832dba4616c4dcb83c9c