### PR TITLE
Implement service JWT auth dependency

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,9 @@ LANGCHAIN_API_KEY=your-langchain-key
 LANGCHAIN_PROJECT=your-project
 SENTRY_DSN=https://example.com/0
 SECRET_KEY=changeme
+SERVICE_SECRET=service-jwt-secret
 OPENMETER_API_KEY=openmeter-key
+# Allowed origins for requests, comma separated or JSON list
+BACKEND_CORS_ORIGINS=http://localhost:3000
 # Uncomment and adjust if running Redis elsewhere
 # REDIS_URL=redis://localhost:6379/0

--- a/.env.test
+++ b/.env.test
@@ -3,5 +3,7 @@ LANGCHAIN_API_KEY=test-langchain-key
 LANGCHAIN_PROJECT=test-project
 SENTRY_DSN=http://public@example.com/0
 SECRET_KEY=test-secret
+SERVICE_SECRET=test-service-secret
 OPENMETER_API_KEY=test-openmeter-key
+ENVIRONMENT=local
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 1. Install Python 3.12 and create a virtual environment.
 2. Install the project dependencies, for example using `pip install -e .`.
-3. Copy `.env.example` to `.env` and fill in the required values (`OPENAI_API_KEY`, `LANGCHAIN_API_KEY`, `LANGCHAIN_PROJECT`, `SENTRY_DSN`, `SECRET_KEY`, `OPENMETER_API_KEY`).
+3. Copy `.env.example` to `.env` and fill in the required values (`OPENAI_API_KEY`, `LANGCHAIN_API_KEY`, `LANGCHAIN_PROJECT`, `SENTRY_DSN`, `SECRET_KEY`, `SERVICE_SECRET`, `OPENMETER_API_KEY`, `BACKEND_CORS_ORIGINS`).
 4. (Optional) Copy `riskgpt.toml.example` to `riskgpt.toml` if you want to use the RiskGPT prompts locally.
 
 ## Development

--- a/src/auth/dependencies.py
+++ b/src/auth/dependencies.py
@@ -1,5 +1,7 @@
-from fastapi import Request
+from fastapi import Header, Request
+import jwt
 
+from src.core.config import settings
 from src.utils.exceptions import AuthenticationException
 
 
@@ -7,10 +9,33 @@ async def get_current_user(request: Request):
     """
     Dependency to enforce token validation and access control.
     """
-    token = getattr(request.state, 'token', None)
-    user_id = getattr(request.state, 'user_id', None)
+    token = getattr(request.state, "token", None)
+    user_id = getattr(request.state, "user_id", None)
 
     if not token or not user_id:
-        raise AuthenticationException(detail='Unauthorized')
+        raise AuthenticationException(detail="Unauthorized")
 
-    return {'token': token, 'user_id': user_id}
+    return {"token": token, "user_id": user_id}
+
+
+async def verify_service_jwt(authorization: str | None = Header(None)) -> None:
+    """Validate service JWT from Authorization header."""
+    if settings.ENVIRONMENT == "local":  # skip auth locally
+        return
+
+    if not authorization or not authorization.startswith("Bearer "):
+        raise AuthenticationException(detail="Missing service token")
+
+    token = authorization.split(" ", 1)[1]
+    try:
+        jwt.decode(
+            token,
+            settings.SERVICE_SECRET,
+            algorithms=[settings.AUTH_TOKEN_ALGORITHM],
+            options={"require": ["exp", "iss"]},
+            issuer="projectrm-backend",
+        )
+    except jwt.ExpiredSignatureError as exc:
+        raise AuthenticationException(detail="Token has expired") from exc
+    except jwt.InvalidTokenError as exc:  # includes incorrect issuer
+        raise AuthenticationException(detail="Invalid token") from exc

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 from typing import Annotated, Any, Literal
+import json
 
 from dotenv import load_dotenv, find_dotenv
 from pydantic import AnyUrl, BeforeValidator, computed_field
@@ -10,62 +10,84 @@ class RiskGPTSettings(BaseSettings):
     """Settings for RiskGPT related configuration."""
 
     model_config = SettingsConfigDict(
-        env_file='.env', env_prefix='RISKGPT_', env_ignore_empty=True, extra='ignore'
+        env_file=".env", env_prefix="RISKGPT_", env_ignore_empty=True, extra="ignore"
     )
 
     OPENAI_API_KEY: str | None = None
     MODEL_NAME: str | None = None
     TEMPERATURE: float | None = None
 
+
 DOTENV = find_dotenv(usecwd=True)
 load_dotenv(DOTENV)
 
 
 def parse_cors(v: Any) -> list[str] | str:
-    if isinstance(v, str) and not v.startswith('['):
-        return [i.strip() for i in v.split(',')]
-    elif isinstance(v, list | str):
-        return v
-    raise ValueError(v)
+    """Parse BACKEND_CORS_ORIGINS from env allowing comma separated strings."""
+    if not v:
+        return []
+
+    if isinstance(v, str):
+        if v == "*":
+            return v
+        if v.startswith("["):
+            try:
+                origins = json.loads(v)
+            except ValueError as e:  # pragma: no cover - invalid env value
+                raise ValueError(v) from e
+        else:
+            origins = v.split(",")
+    elif isinstance(v, list):
+        origins = v
+    else:
+        raise ValueError(v)
+
+    cleaned = []
+    for origin in origins:
+        s = str(origin).strip().rstrip("/")
+        if s and s not in cleaned:
+            cleaned.append(s)
+    return cleaned
 
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_file='.env', env_ignore_empty=True, extra='ignore')
-    DOMAIN: str = 'localhost'
-    ENVIRONMENT: Literal['local', 'staging', 'production'] = 'production'
+    model_config = SettingsConfigDict(env_file=".env", env_ignore_empty=True, extra="ignore")
+    DOMAIN: str = "localhost"
+    ENVIRONMENT: Literal["local", "staging", "production"] = "production"
 
     BACKEND_CORS_ORIGINS: Annotated[list[AnyUrl] | str, BeforeValidator(parse_cors)] = []
 
     @computed_field
     @property
     def IS_PRODUCTION(self) -> bool:
-        return self.ENVIRONMENT == 'production'
+        return self.ENVIRONMENT == "production"
 
     APP_PORT: int = 8001
-    APP_HOST: str = 'localhost'
+    APP_HOST: str = "localhost"
     OPENAI_API_KEY: str
     LANGCHAIN_API_KEY: str
     LANGCHAIN_TRACING_V2: bool = False
     LANGCHAIN_CALLBACKS_BACKGROUND: bool = False
     LANGCHAIN_PROJECT: str
 
-    OPENAI_MODEL_NAME: str = 'gpt-4o-mini'
+    OPENAI_MODEL_NAME: str = "gpt-4o-mini"
     OPENAI_TEMPERATURE: float = 0.7
 
-    REDIS_URL: str = 'redis://localhost:6379/0'
+    REDIS_URL: str = "redis://localhost:6379/0"
     CACHE_TIMEOUT: int = 60 * 60 * 24
 
     SENTRY_DSN: str
-    LOG_LEVEL: str = 'ERROR'
+    LOG_LEVEL: str = "ERROR"
 
     SECRET_KEY: str
+    SERVICE_SECRET: str
     AUTH_TOKEN_LEEWAY: int = 0  # in seconds
-    AUTH_TOKEN_ALGORITHM: str = 'HS256'
-    AUTH_TOKEN_AUDIENCE: str = 'fastapi-users:auth'
+    AUTH_TOKEN_ALGORITHM: str = "HS256"
+    AUTH_TOKEN_AUDIENCE: str = "fastapi-users:auth"
 
     OPENMETER_API_KEY: str
-    OPENMETER_API_URL: str = 'https://openmeter.cloud'
-    OPENMETER_SOURCE: str = 'prm-ai-service'
+    OPENMETER_API_URL: str = "https://openmeter.cloud"
+    OPENMETER_SOURCE: str = "prm-ai-service"
 
     @classmethod
     def from_env(cls):

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -1,0 +1,37 @@
+import jwt
+from datetime import datetime, timedelta
+from fastapi import FastAPI, Depends
+from fastapi.testclient import TestClient
+
+from src.auth.dependencies import verify_service_jwt
+from src.core.config import settings
+
+app = FastAPI(dependencies=[Depends(verify_service_jwt)])
+
+
+@app.get("/protected")
+async def protected():
+    return {"ok": True}
+
+
+def _make_token(**payload):
+    data = {"iss": "projectrm-backend", "exp": datetime.utcnow() + timedelta(minutes=5)}
+    data.update(payload)
+    return jwt.encode(data, settings.SERVICE_SECRET, algorithm=settings.AUTH_TOKEN_ALGORITHM)
+
+
+def test_service_jwt_valid(monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    token = _make_token()
+    with TestClient(app) as client:
+        res = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+        assert res.status_code == 200
+        assert res.json() == {"ok": True}
+
+
+def test_service_jwt_invalid(monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    token = _make_token(iss="other")
+    with TestClient(app) as client:
+        res = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+        assert res.status_code == 401


### PR DESCRIPTION
## Summary
- add `SERVICE_SECRET` and `BACKEND_CORS_ORIGINS` to env files and README
- extend CORS parsing to sanitize origins
- add global service JWT verification dependency
- update FastAPI app to use new dependency
- provide unit tests for service JWT auth

## Testing
- `ruff check src/auth/dependencies.py src/core/config.py src/main.py tests/test_service_auth.py`
- `black --check src/auth/dependencies.py src/core/config.py src/main.py tests/test_service_auth.py`
- `poetry run mypy src/auth/dependencies.py src/core/config.py src/main.py tests/test_service_auth.py` *(fails: Missing named argument "OPENAI_API_KEY" for "Settings" etc.)*
- `pytest -m "not webtest"` *(fails: cannot import name 'Undefined' from 'pydantic.fields')*

------
https://chatgpt.com/codex/tasks/task_e_684964372254832db6f99ec95ed0393c