### PR TITLE
Add RiskGPT workflow services

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ Use `/api/context/check/` with a `ContextQualityRequest` payload to analyse the
 quality of a project context. The service returns a `ContextQualityResponse`
 containing a quality score and rationale.
 
+### External context endpoint
+
+Use `/api/context/external/` with an `ExternalContextRequest` to gather relevant
+external information. The endpoint returns an `ExternalContextResponse`.
+
+### Presentation endpoint
+
+Send a `PresentationRequest` to `/api/presentation/` to create presentation-ready
+summaries. The service responds with a `PresentationResponse`.
+
+### Risk workflow endpoint
+
+The `/api/risk/workflow/` route executes the full risk workflow. Provide a
+`RiskRequest` and receive a `RiskResponse` with references and document IDs.
+
 ## Documentation
 
 The project documentation is built with MkDocs and can be found in the `docs` directory. To view the documentation locally, run:

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,3 +14,21 @@ package and its configuration file are installed.
 Send a `ContextQualityRequest` to `/api/context/check/` to assess the quality of
 a project context. The endpoint returns a `ContextQualityResponse` with a score
 and rationale.
+
+## External context enrichment
+
+Use `/api/context/external/` with an `ExternalContextRequest` payload to gather
+news, professional, regulatory and peer information. The service returns an
+`ExternalContextResponse` summarising the findings.
+
+## Presentation workflow
+
+The `/api/presentation/` endpoint takes a `PresentationRequest` and returns a
+`PresentationResponse` containing presentation-ready summaries tailored to the
+requested audience.
+
+## Risk workflow
+
+Send a `RiskRequest` to `/api/risk/workflow/` to run the complete risk
+identification and assessment workflow. The endpoint responds with a
+`RiskResponse` including references and document links.

--- a/tests/test_risk_workflows.py
+++ b/tests/test_risk_workflows.py
@@ -1,0 +1,69 @@
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+from riskgpt.models import schemas as rg_schemas
+from src.main import app
+
+client = TestClient(app)
+
+
+@patch("src.services.services.ContextQualityService.execute_query")
+def test_context_quality_endpoint(mock_execute):
+    mock_execute.return_value = rg_schemas.ContextQualityResponse(
+        shortcomings=["too short"],
+        rationale="r",
+        suggested_improvements="i",
+        response_info=None,
+    )
+    payload = {"business_context": {"project_id": "p"}}
+    response = client.post("/api/context/check/", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["shortcomings"] == ["too short"]
+
+
+@patch("src.services.services.ExternalContextService.execute_query")
+def test_external_context_endpoint(mock_execute):
+    mock_execute.return_value = rg_schemas.ExternalContextResponse(
+        sector_summary="sum",
+        external_risks=["r1"],
+        source_table=[{"title": "t", "url": "u"}],
+        workshop_recommendations=["rec"],
+        full_report=None,
+        response_info=None,
+    )
+    payload = {"business_context": {"project_id": "p"}}
+    response = client.post("/api/context/external/", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["sector_summary"] == "sum"
+
+
+@patch("src.services.services.PresentationWorkflowService.execute_query")
+def test_presentation_workflow_endpoint(mock_execute):
+    mock_execute.return_value = rg_schemas.PresentationResponse(
+        executive_summary="exec", main_risks=["r"], response_info=None
+    )
+    payload = {
+        "business_context": {"project_id": "p"},
+        "audience": "executive",
+    }
+    response = client.post("/api/presentation/", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert data["executive_summary"] == "exec"
+
+
+@patch("src.services.services.RiskWorkflowService.execute_query")
+def test_risk_workflow_endpoint(mock_execute):
+    mock_execute.return_value = rg_schemas.RiskResponse(
+        risks=[rg_schemas.Risk(title="t", description="d", category="c")],
+        references=None,
+        response_info=None,
+    )
+    payload = {"business_context": {"project_id": "p"}, "category": "c"}
+    response = client.post("/api/risk/workflow/", json=payload)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["risks"]) == 1
+


### PR DESCRIPTION
## Summary
- expose RiskGPT workflow endpoints
- document new endpoints
- test new workflow routes

## Testing
- `ENVIRONMENT=local .venv/bin/pytest -m "not webtest" -q`

------
https://chatgpt.com/codex/tasks/task_e_6849648ecaf8832d909b441086678f3c