### PR TITLE
Switch to Authorization headers

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,17 @@
+# Authentication
+
+This service uses JSON Web Tokens (JWT) supplied in the `Authorization` header to authenticate requests.
+The `TokenExtractionMiddleware` reads the header, decodes the token with `get_jwt_payload` and stores
+both the raw token and the user identifier on `request.state`.
+
+Authentication is bypassed when `ENVIRONMENT` is set to `local`. In this case dummy
+values are stored so that the rest of the application can operate without valid credentials.
+
+The expected header format is:
+
+```http
+Authorization: Bearer <token>
+```
+
+If the header is missing or malformed, an `AuthenticationException` is raised and the
+request will receive a `401` response.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ theme:
 nav:
   - Home: index.md
   - Services and Routes: services_and_routes.md
+  - Authentication: authentication.md
   - Error Handling: error_handling.md
   - Resilient Execution: resilient_execution.md
   - Improvement Tasks: tasks.md

--- a/src/auth/auth.py
+++ b/src/auth/auth.py
@@ -10,7 +10,7 @@ from src.utils.exceptions import AuthenticationException
 
 def get_jwt_payload(request: Request) -> dict[str, Any]:
     """
-    Extract and verify JWT token from the cookie.
+    Extract and verify JWT token from the ``Authorization`` header.
     In local environment, authentication is bypassed.
     """
     # Skip authentication in local environment
@@ -18,9 +18,11 @@ def get_jwt_payload(request: Request) -> dict[str, Any]:
         # Return a dummy payload with a user ID
         return {"sub": "00000000-0000-0000-0000-000000000000"}
 
-    token = request.cookies.get("auth")
-    if not token:
+    auth_header = request.headers.get("Authorization")
+    if not auth_header or not auth_header.startswith("Bearer "):
         raise AuthenticationException(detail="Missing authentication token")
+
+    token = auth_header.split(" ", 1)[1]
 
     try:
         payload = jwt.decode(

--- a/tests/fixtures/client.py
+++ b/tests/fixtures/client.py
@@ -1,5 +1,5 @@
-from fastapi.testclient import TestClient
 import pytest
+from fastapi.testclient import TestClient
 
 from src.main import app
 
@@ -7,7 +7,7 @@ from src.main import app
 @pytest.fixture
 def client():
     with TestClient(app) as c:
-        c.cookies.set('auth', 'test')
+        c.headers.update({"Authorization": "Bearer test"})
         yield c
 
 

--- a/tests/test_auth_header.py
+++ b/tests/test_auth_header.py
@@ -1,0 +1,28 @@
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from src.auth.dependencies import get_current_user
+from src.core.config import settings
+from src.middleware.token_extraction import TokenExtractionMiddleware
+
+app = FastAPI()
+app.add_middleware(TokenExtractionMiddleware)
+
+
+@app.get("/protected")
+async def protected(user=Depends(get_current_user)):
+    return {"user": user}
+
+
+def test_missing_authorization_header(monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    with TestClient(app) as client:
+        res = client.get("/protected")
+        assert res.status_code == 401
+
+
+def test_invalid_authorization_header(monkeypatch):
+    monkeypatch.setattr(settings, "ENVIRONMENT", "production")
+    with TestClient(app) as client:
+        res = client.get("/protected", headers={"Authorization": "Token invalid"})
+        assert res.status_code == 401

--- a/tests/test_risk_workflows.py
+++ b/tests/test_risk_workflows.py
@@ -1,10 +1,12 @@
 from unittest.mock import patch
-from fastapi.testclient import TestClient
 
+from fastapi.testclient import TestClient
 from riskgpt.models import schemas as rg_schemas
+
 from src.main import app
 
 client = TestClient(app)
+client.headers.update({"Authorization": "Bearer test"})
 
 
 @patch("src.services.services.ContextQualityService.execute_query")
@@ -33,7 +35,7 @@ def test_external_context_endpoint(mock_execute):
         response_info=None,
     )
     payload = {"business_context": {"project_id": "p"}}
-    response = client.post("/api/context/external/", json=payload)
+    response = client.post("/api/workflow/context/external/", json=payload)
     assert response.status_code == 200
     data = response.json()
     assert data["sector_summary"] == "sum"
@@ -48,7 +50,7 @@ def test_presentation_workflow_endpoint(mock_execute):
         "business_context": {"project_id": "p"},
         "audience": "executive",
     }
-    response = client.post("/api/presentation/", json=payload)
+    response = client.post("/api/workflow/presentation/", json=payload)
     assert response.status_code == 200
     data = response.json()
     assert data["executive_summary"] == "exec"
@@ -62,8 +64,7 @@ def test_risk_workflow_endpoint(mock_execute):
         response_info=None,
     )
     payload = {"business_context": {"project_id": "p"}, "category": "c"}
-    response = client.post("/api/risk/workflow/", json=payload)
+    response = client.post("/api/workflow/risk/", json=payload)
     assert response.status_code == 200
     data = response.json()
     assert len(data["risks"]) == 1
-


### PR DESCRIPTION
## Summary
- parse bearer tokens in middleware
- read Authorization header in `get_jwt_payload`
- update client fixture and workflow tests
- add new tests for missing/invalid headers
- document authentication method

## Testing
- `pre-commit run --files tests/test_risk_workflows.py tests/test_auth_header.py tests/fixtures/client.py src/middleware/token_extraction.py src/auth/auth.py mkdocs.yml docs/authentication.md`
- `pytest -m "not webtest"`

------
https://chatgpt.com/codex/tasks/task_e_6849a66f1414832d955c8088371ab984