### PR TITLE
Configure OpenMeter test credentials via env var

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -5,7 +5,10 @@ LANGCHAIN_PROJECT=test-project
 SENTRY_DSN=http://public@example.com/0
 SECRET_KEY=test-secret
 SERVICE_SECRET=test-service-secret
-OPENMETER_SANDBOX_URL = https://api.openmeter.io/sandbox
-OPENMETER_SANDBOX_API_KEY = <your_sandbox_key>
+# The OpenMeter sandbox URL used during tests
+OPENMETER_API_URL=https://api.openmeter.io/sandbox
+
+# NOTE: No API key is stored in version control. You must supply
+# OPENMETER_API_KEY in your environment when running the tests.
 
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 Run the tests excluding webtests. Environment variables are loaded from
 `.env.test` using `pytest-dotenv`:
 
+The `.env.test` file does not include an OpenMeter API key. When running the
+quota service tests you must provide `OPENMETER_API_KEY` via an external
+environment variable.
+
 ```bash
 pytest -m "not webtest"
 ```

--- a/tests/services/test_openmeter.py
+++ b/tests/services/test_openmeter.py
@@ -7,6 +7,18 @@ from openmeter import Client
 from src.auth.quota_service import TokenQuotaService
 from src.core.config import settings
 
+# Skip tests when the OpenMeter API key is not provided or still set to a
+# placeholder value. The key must be supplied via an external environment
+# variable when running the tests.
+if not settings.OPENMETER_API_KEY or settings.OPENMETER_API_KEY in {
+    "openmeter-key",
+    "<your_sandbox_key>",
+}:
+    pytest.skip(
+        "OPENMETER_API_KEY not configured for integration tests",
+        allow_module_level=True,
+    )
+
 
 # Fixtures for sandbox client and test subject
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary
- require external OPENMETER_API_KEY when running tests
- document the new requirement in README
- skip OpenMeter integration tests if API key isn't provided
- set OPENMETER_API_URL in `.env.test`

## Testing
- `pytest -m "not webtest"` *(fails: No module named 'sentry_sdk')*

------
https://chatgpt.com/codex/tasks/task_e_684b128ee568832dbc4c923dec0f3ae2