### PR TITLE
Mark webtest and doc update

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Run the tests excluding webtests. Environment variables are loaded from
 pytest -m "not webtest"
 ```
 
+To execute the webtests (which interact with OpenMeter's sandbox), set
+`OPENMETER_SANDBOX_API_KEY` and run pytest with the `--webtest` flag:
+
+```bash
+OPENMETER_SANDBOX_API_KEY=<your_key> pytest --webtest
+```
+
 ### Testing APIs without Protection
 
 In the local environment (`ENVIRONMENT=local` in `.env`), API authentication and metering protections are automatically disabled. This allows you to test the APIs without needing to provide authentication tokens or worrying about token quota limitations.

--- a/tests/services/test_openmeter.py
+++ b/tests/services/test_openmeter.py
@@ -42,6 +42,7 @@ async def entitlement_setup(sandbox_client, test_subject):
 
 
 @pytest.mark.asyncio
+@pytest.mark.webtest
 async def test_reserve_and_adjust_tokens(
     entitlement_setup, sandbox_client, test_subject, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- mark `test_reserve_and_adjust_tokens` as `webtest`
- update README with instructions for running webtests

## Testing
- `OPENMETER_API_KEY=dummy OPENMETER_API_URL=https://example.com pytest -m "not webtest" -q` *(fails: ModuleNotFoundError: No module named 'riskgpt')*

------
https://chatgpt.com/codex/tasks/task_e_684b12a832cc832dbc148fd6a1c2c662