### PR TITLE
Update Request creation in token quota test

### DIFF
--- a/tests/services/test_openmeter.py
+++ b/tests/services/test_openmeter.py
@@ -46,25 +46,21 @@ async def test_reserve_and_adjust_tokens(
     entitlement_setup, sandbox_client, test_subject, monkeypatch
 ):
     monkeypatch.setattr(settings, "ENVIRONMENT", "testing123")
+    async def receive() -> dict:
+        return {"type": "http.request", "body": b""}
+
     req: Request = Request(
         scope={
             "type": "http",
             "method": "POST",
             "path": "/test",
-            "body": {
-                "model_name": "gpt-test",
-                "prompt_name": "unit-test",
-                "tokens": 200,
-            },
+            "headers": [(b"accept", b"application/json")],
             "state": {
                 "token": "test_token",
                 "user_id": str(test_subject),
             },
-            "headers": [
-                (b"authorization", f"Bearer {settings.OPENMETER_API_KEY}".encode()),
-                (b"accept", b"application/json"),
-            ],
-        }
+        },
+        receive=receive,
     )
     # Ensure we are in test environment
     service = TokenQuotaService(request=req)


### PR DESCRIPTION
## Summary
- create test Request with only required ASGI keys and minimal receive coroutine
- drop unused `body` field and auth header

## Testing
- `pytest tests/services/test_openmeter.py::test_reserve_and_adjust_tokens -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_684b12bad950832d910e551be6080844