### PR TITLE
Improve OpenMeter test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ To use this feature:
 2. Start the application normally
 3. Make API requests without authentication tokens
 
+### OpenMeter Sandbox Test
+
+The `tests/services/test_openmeter.py` integration test exercises the
+OpenMeter sandbox. It creates a temporary subject and issues an initial
+entitlement of 1000 tokens for that user. The subject and entitlement are
+deleted when the test completes.
+
+To run this test you must provide valid sandbox credentials via
+`OPENMETER_API_URL` and `OPENMETER_API_KEY` and have an active internet
+connection.
+
 ## Authentication
 
 In staging and production environments you must provide a valid JSON Web Token in the request headers. The API expects the following format:

--- a/tests/services/test_openmeter.py
+++ b/tests/services/test_openmeter.py
@@ -1,3 +1,5 @@
+"""Integration test of the OpenMeter sandbox."""
+
 import uuid
 
 import pytest
@@ -6,6 +8,18 @@ from openmeter import Client
 
 from src.auth.quota_service import TokenQuotaService
 from src.core.config import settings
+
+"""
+Prerequisites
+-------------
+- Valid sandbox API key and URL in the environment (`OPENMETER_API_KEY` and
+  `OPENMETER_API_URL`).
+- Active internet connection to reach the sandbox service.
+
+The `create_entitlement` call issues an initial allowance of ``1000`` tokens for
+the temporary test subject. Both the entitlement and the subject are deleted in
+the fixture teardowns so the sandbox remains clean after the test run.
+"""
 
 
 # Fixtures for sandbox client and test subject
@@ -33,7 +47,7 @@ async def entitlement_setup(sandbox_client, test_subject):
         featureKey="ai_tokens",
         type="metered",
         usagePeriod={"interval": "MONTH"},
-        issueAfterReset=1000,
+        issueAfterReset=1000,  # initial grant of 1000 tokens for the test user
         isSoftLimit=False,
     )
     yield ent


### PR DESCRIPTION
## Summary
- document OpenMeter sandbox preconditions in `test_openmeter.py`
- note creation of 1000-token entitlement and cleanup
- add README section describing how to run the OpenMeter sandbox test

## Testing
- `pytest -m "not webtest"` *(fails: missing settings and dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684b12c4f52c832db1b5d031fef44543