### PR TITLE
Fix service JWT header

### DIFF
--- a/src/auth/dependencies.py
+++ b/src/auth/dependencies.py
@@ -25,15 +25,18 @@ async def get_current_user(request: Request) -> dict[str, str]:
     return {"token": token, "user_id": user_id}
 
 
-async def verify_service_jwt(request: Request, authorization: str | None = Header(None)) -> None:
-    """Validate service JWT from Authorization header."""
+async def verify_service_jwt(
+    request: Request,
+    service_authorization: str | None = Header(None, alias="X-Service-Authorization"),
+) -> None:
+    """Validate service JWT from ``X-Service-Authorization`` header."""
     if settings.ENVIRONMENT == "local":  # skip auth locally
         return
 
-    if not authorization or not authorization.startswith("Bearer "):
+    if not service_authorization or not service_authorization.startswith("Bearer "):
         raise AuthenticationException(detail="Missing service token")
 
-    token = authorization.split(" ", 1)[1]
+    token = service_authorization.split(" ", 1)[1]
     try:
         jwt.decode(
             token,

--- a/tests/test_service_auth.py
+++ b/tests/test_service_auth.py
@@ -25,7 +25,7 @@ def test_service_jwt_valid(monkeypatch):
     monkeypatch.setattr(settings, "ENVIRONMENT", "production")
     token = _make_token()
     with TestClient(app) as client:
-        res = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+        res = client.get("/protected", headers={"X-Service-Authorization": f"Bearer {token}"})
         assert res.status_code == 200
         assert res.json() == {"ok": True}
 
@@ -34,7 +34,7 @@ def test_service_jwt_invalid(monkeypatch):
     monkeypatch.setattr(settings, "ENVIRONMENT", "production")
     token = _make_token(iss="other")
     with TestClient(app) as client:
-        res = client.get("/protected", headers={"Authorization": f"Bearer {token}"})
+        res = client.get("/protected", headers={"X-Service-Authorization": f"Bearer {token}"})
         assert res.status_code == 401
 
 


### PR DESCRIPTION
## Summary
- read service JWT from `X-Service-Authorization` header
- update service auth tests

## Testing
- `pytest tests/test_service_auth.py::test_service_jwt_valid -q` *(fails: No module named 'riskgpt')*

------
https://chatgpt.com/codex/tasks/task_e_684d7ede19b0832d94cab1f2ddd5a171